### PR TITLE
Grind the right way up?

### DIFF
--- a/Source/Scenes/LevelItems/Rail.tscn
+++ b/Source/Scenes/LevelItems/Rail.tscn
@@ -28,4 +28,3 @@ collision_mask = 1048575
 build_mode = 1
 polygon = PoolVector2Array( 0, 0, 0, 0, 0, 0 )
 one_way_collision_margin = 2.2
-[connection signal="area_entered" from="Area2D" to="." method="_on_Area2D_area_entered"]

--- a/Source/Scripts/LevelItems/BounceRing.gd
+++ b/Source/Scripts/LevelItems/BounceRing.gd
@@ -58,6 +58,6 @@ func _on_Ring_area_entered (area) -> void:
 	if not collected and area.name == "Player" and collectionStartTimer <= 0:
 		collected = true					# set collected to true
 		sprite.animation = "Sparkle"		# set the animation to the sparkle
-		audio.play ();						# play the ring sfx
+		audio.play ()						# play the ring sfx
 		get_node ("/root/Node2D/CanvasLayer/RingCounter").addRing ()	# add a ring to the total
 	return

--- a/Source/Scripts/LevelItems/Rail.gd
+++ b/Source/Scripts/LevelItems/Rail.gd
@@ -8,6 +8,7 @@ onready var line = get_node ("Line2D")
 onready var coll = get_node ("Area2D/CollisionPolygon2D")
 
 func _ready () -> void:
+	helper_functions._whocares = $"Area2D".connect ("area_entered", self, "_on_Area2D_area_entered")
 	# set the line points for rendering 
 	line.points = curve.get_baked_points ()
 
@@ -32,4 +33,5 @@ func _on_Area2D_area_entered (area) -> void:
 	# know it should be grinding now.
 	if (area.name == "Player"):
 		area._on_Railgrind (area, curve, global_position)
+		area.rotation = 0.0
 	return

--- a/Source/Scripts/LevelItems/air_furniture.gd
+++ b/Source/Scripts/LevelItems/air_furniture.gd
@@ -11,7 +11,7 @@ export(bool) var ringScale = false
 
 onready var animation = find_node ("AnimatedSprite")	# stores the animated sprite
 onready var sound = find_node ("AudioStreamPlayer")		# stores the audio stream player
-var scaling = 1	# stores the current scale of the spring
+var scaling = 1											# stores the current scale of the spring
 
 func _ready () -> void:
 	helper_functions._whocares = self.connect ("area_entered", self, "_on_Area2D_area_entered")

--- a/Source/Scripts/UI/HUD/BoostBar.gd
+++ b/Source/Scripts/UI/HUD/BoostBar.gd
@@ -22,7 +22,7 @@ func _ready () -> void:
 
 func _process (_delta) -> void:
 	if (visualBar < boostAmount and visualBar <= 60):
-		visualBar += 0.5;
+		visualBar += 0.5
 		barItems [floor (fmod (visualBar-2, 20))].rect_scale.x = 4
 	else:
 		visualBar = boostAmount


### PR DESCRIPTION
Using the simplest way of dealing with this.

- Reset the player's rotation to 0 when they start grinding.

Haven't seen this happen in testing since, but equally this particular bug is hard to reproduce reliably. So either it is fixed, or just (at best) made harder to reproduce.

Fixes #5 

Signed-off-by: Stuart "Sslaxx" Moore <stuart@sslaxx.co.uk>