### PR TITLE
Cleaning up after the rings.

### DIFF
--- a/Source/Scripts/LevelItems/Ring.gd
+++ b/Source/Scripts/LevelItems/Ring.gd
@@ -18,6 +18,7 @@ var boostBar
 func _process (_delta) -> void:
 	if (collected and sprite.animation == "Sparkle" and sprite.frame >= 6):
 		visible = false
+		queue_free ()
 	return
 
 func _on_Ring_area_entered (area) -> void:

--- a/Source/Scripts/LevelItems/RingSpawner.gd
+++ b/Source/Scripts/LevelItems/RingSpawner.gd
@@ -41,6 +41,10 @@ func _process (_delta) -> void:
 		placeRings ()
 		if (not pposList == posList):
 			update ()
+	else:
+		# During the game, if there're no rings left parented to the spawner, delete it.
+		if (get_child_count () < 1):
+			queue_free ()
 	return
 
 # draw the circles for the rings


### PR DESCRIPTION
To avoid things cluttering up the scene tree more than necessary:

- queue_free the rings after they're collected.
- queue_free the ring spawners after all their rings have been collected.

Signed-off-by: Stuart "Sslaxx" Moore <stuart@sslaxx.co.uk>