### PR TITLE
Debug HUD time.

### DIFF
--- a/Source/Scenes/UI/HUD/debug_hud.tscn
+++ b/Source/Scenes/UI/HUD/debug_hud.tscn
@@ -1,0 +1,163 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://Assets/Fonts/IBMPlexMono-Regular-16.tres" type="DynamicFont" id=1]
+[ext_resource path="res://Scripts/UI/HUD/debug_hud.gd" type="Script" id=2]
+
+[node name="debug_hud" type="CanvasLayer"]
+layer = 64
+script = ExtResource( 2 )
+
+[node name="Position" type="Label" parent="."]
+margin_left = 800.0
+margin_right = 1020.0
+margin_bottom = 22.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "POSITION: XXXXX, YYYYY"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="FPS" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 22.0
+margin_right = 1020.0
+margin_bottom = 44.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "FPS: XXXXX"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Boosting" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 44.0
+margin_right = 1020.0
+margin_bottom = 66.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Crouching" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 66.0
+margin_right = 1020.0
+margin_bottom = 88.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Flying" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 88.0
+margin_right = 1020.0
+margin_bottom = 110.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Gliding" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 112.0
+margin_right = 1020.0
+margin_bottom = 134.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Jumping" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 134.0
+margin_right = 1020.0
+margin_bottom = 156.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Rolling" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 156.0
+margin_right = 1020.0
+margin_bottom = 178.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Spindashing" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 178.0
+margin_right = 1020.0
+margin_bottom = 200.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Stomping" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 200.0
+margin_right = 1020.0
+margin_bottom = 222.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Tricking" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 224.0
+margin_right = 1020.0
+margin_bottom = 246.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Unmoveable" type="Label" parent="."]
+margin_left = 800.0
+margin_top = 246.0
+margin_right = 1020.0
+margin_bottom = 268.0
+custom_fonts/font = ExtResource( 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "IS BOOSTING: NO"
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/Source/Scripts/Levels/level_generic.gd
+++ b/Source/Scripts/Levels/level_generic.gd
@@ -2,15 +2,19 @@
 # Sets up the generic patterns for a level.
 
 extends Node2D
+
 export(String, FILE, "*.ogg") var music_file	# Specify a file to be played.
 
 func _ready () -> void:
-	if (music_file != ""):	# If there's a music file specified, play it.
+	if (not music_file == ""):	# If there's a music file specified, play it.
 		music_player.play_music (music_file)
 	if (not has_node ("/root/Level/game_hud")):	# Make sure the HUD is added to the level space.
 		helper_functions.add_path_to_node ("res://Scenes/UI/HUD/game_hud.tscn", "/root/Level")
 		yield (get_tree (), "idle_frame")		# And make sure they're added before continuing...
 	if (not has_node ("/root/Level/Player")):	# No player? Add them to the scene.
 		helper_functions.add_path_to_node ("res://Scenes/Player/player_sonic.tscn", "/root/Level")
+		yield (get_tree (), "idle_frame")		# And make sure they're added before continuing...
+	if (OS.is_debug_build ()):					# Running in debug mode?
+		helper_functions.add_path_to_node ("res://Scenes/UI/HUD/debug_hud.tscn", "/root/Level")
 		yield (get_tree (), "idle_frame")		# And make sure they're added before continuing...
 	return

--- a/Source/Scripts/Player/player_generic.gd
+++ b/Source/Scripts/Player/player_generic.gd
@@ -226,7 +226,9 @@ func reset_game () -> void:
 	reset_character ()
 	game_space.reset_game_space ()
 	game_space.get_node ("level_timer").stop ()
-	helper_functions._whocares = helper_functions.change_scene ("res://Scenes/UI/main_menu.tscn")
+	if (not helper_functions.change_scene ("res://Scenes/UI/main_menu.tscn") == OK):
+		printerr ("Unable to load the main menu!")
+		get_tree ().quit ()
 	music_player.stop_music ()
 	return
 

--- a/Source/Scripts/UI/HUD/debug_hud.gd
+++ b/Source/Scripts/UI/HUD/debug_hud.gd
@@ -1,0 +1,26 @@
+### debug_hud.gd
+# Displays assorted information that's useful while debugging.
+# As this runs constantly, it only gets added to the scene when in debug mode.
+
+extends CanvasLayer
+
+func _ready () -> void:
+	if (!OS.is_debug_build ()):		# If not running in debug mode, remove this.
+		queue_free ()
+	return
+
+func _process (_delta) -> void:
+	$"Position".text = "POSITION: " + var2str (int (game_space.player_node.position.x)) + ", " + \
+		var2str (int (game_space.player_node.position.y))
+	$"FPS".text = "FPS: " + var2str (Engine.get_frames_per_second ())
+	$"Boosting".text = "BOOSTING: " + ("YES" if not game_space.player_node.is_boosting == 0 else "NO")
+	$"Crouching".text = "CROUCHING: " + ("YES" if game_space.player_node.is_crouching else "NO")
+	$"Flying".text = "FLYING: " + ("YES" if game_space.player_node.is_flying else "NO")
+	$"Gliding".text = "GLIDING: " + ("YES" if game_space.player_node.is_gliding else "NO")
+	$"Jumping".text = "JUMPING: " + ("YES" if game_space.player_node.is_jumping else "NO")
+	$"Rolling".text = "ROLLING: " + ("YES" if game_space.player_node.is_rolling else "NO")
+	$"Spindashing".text = "SPINDASHING: " + ("YES" if game_space.player_node.is_spindashing else "NO")
+	$"Stomping".text = "STOMPING: " + ("YES" if game_space.player_node.is_stomping else "NO")
+	$"Tricking".text = "TRICKING: " + ("YES" if game_space.player_node.is_tricking else "NO")
+	$"Unmoveable".text = "UNMOVEABLE: " + ("YES" if game_space.player_node.is_unmoveable else "NO")
+	return

--- a/Source/Scripts/UI/menu_main.gd
+++ b/Source/Scripts/UI/menu_main.gd
@@ -16,7 +16,9 @@ func _ready () -> void:
 ## btnNewGame_on_press
 # Starts a new game!
 func btnNewGame_on_press () -> void:
-	helper_functions._whocares = helper_functions.change_scene ("res://Scenes/Levels/ChaosFestival.tscn")
+	if (not helper_functions.change_scene ("res://Scenes/Levels/ChaosFestival.tscn") == OK):
+		printerr ("Unable to load the test level!")
+		get_tree ().quit ()
 	return
 
 ## btnOptions_on_press

--- a/Source/Scripts/scn_preload.gd
+++ b/Source/Scripts/scn_preload.gd
@@ -14,5 +14,7 @@ func _ready () -> void:
 	sound_player.add_sound_to_library ("res://Assets/Audio/Sound/Player/Death.ogg", "player_death")
 	sound_player.add_sound_to_library ("res://Assets/Audio/Sound/Player/jump.ogg", "player_jump")
 	sound_player.add_sound_to_library ("res://Assets/Audio/Sound/LevelItems/ring.ogg", "ring_get")
-	helper_functions._whocares = helper_functions.change_scene ("res://Scenes/UI/main_menu.tscn")
+	if (not helper_functions.change_scene ("res://Scenes/UI/main_menu.tscn") == OK):
+		printerr ("ERROR: Unable to load the main scene!")
+		get_tree ().quit ()
 	return

--- a/Source/project.godot
+++ b/Source/project.godot
@@ -34,12 +34,12 @@ game_space="*res://Scenes/Singletons/game_space.tscn"
 
 [debug]
 
-settings/stdout/print_fps=true
 settings/stdout/verbose_stdout=true
 
 [display]
 
 window/size/height=576
+window/vsync/use_vsync=false
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 


### PR DESCRIPTION
* Added basic debug HUD functionality. So far it'll report on: the player's position; frame rate; if they're boosting, crouching, jumping etc.
* As frame rate is now a function of the debug HUD, removed the project setting for it. FPS is now only displayed while in a game level.
* The default layer for the debug HUD's canvas is 64, so it will appear on top of the normal HUD if necessary.
* Should something weird happen and changing scene is no longer possible, the game will error out and quit instead of sitting there.

Signed-off-by: Stuart "Sslaxx" Moore <stuart@sslaxx.co.uk>