### PR TITLE
Start checkpoints, zero time!

### DIFF
--- a/Source/Scripts/LevelItems/item_checkpoint.gd
+++ b/Source/Scripts/LevelItems/item_checkpoint.gd
@@ -3,7 +3,7 @@
 
 extends Area2D
 
-export(Vector2) var last_time = Vector2.ZERO		# Time when the player passes the checkpoint.
+var last_time:Vector2 = Vector2.ZERO		# Time when the player passes the checkpoint.
 var passed_checkpoint:bool = false					# Passed the checkpoint yet?
 
 func _ready() -> void:

--- a/Source/Scripts/Player/player_generic.gd
+++ b/Source/Scripts/Player/player_generic.gd
@@ -155,6 +155,7 @@ func _ready () -> void:
 		game_space.last_checkpoint = $"/root/Level/start_point"
 		game_space.last_checkpoint.passed_checkpoint = true	# So it doesn't get triggered by mistake.
 		game_space.last_checkpoint.visible = false			# In case the dev forgets!
+		game_space.last_checkpoint.last_time = Vector2.ZERO
 		position = $"/root/Level/start_point".position
 	else:
 		printerr ("You shouldn't see this - did you forget to set start_point?")


### PR DESCRIPTION
* When the player is instantiated, and there's a start_point, make sure that its timer value is explicitly set to zero.

Signed-off-by: Stuart "Sslaxx" Moore <stuart@sslaxx.co.uk>